### PR TITLE
Fix/cannot execute scripts in docker container

### DIFF
--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -36,6 +36,8 @@ jobs:
         load: true
         build-args: |
           packageScope=@awesome-backup/${{ matrix.testingTargetBaseName }}
+          packagePath=apps/${{ matrix.testingTargetBaseName }}
+          dbType=${{ matrix.testingTargetBaseName }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
         tags: awesome-backup/${{ matrix.testingTargetBaseName }}:latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,7 +71,7 @@ RUN apt-get update \
 FROM tool-common AS postgresql
 
 RUN apt-get update \
-      && apt-get postgresql-common --no-install-recommends \
+      && apt-get install -y postgresql-common --no-install-recommends \
       && apt-get clean \
       && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,5 @@
+ARG dbType
+
 FROM node:16-slim AS base
 
 ##
@@ -49,15 +51,50 @@ RUN yarn run turbo run build --scope="${packageScope}" --include-dependencies --
 
 
 ##
-## release
+## tools
 ##
-FROM base AS release
+FROM base AS tool-common
 
+RUN apt-get update \
+      && apt-get install -y bzip2 \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/*
+
+FROM tool-common AS mongodb
+
+ADD https://fastdl.mongodb.org/tools/db/mongodb-database-tools-debian10-x86_64-100.5.2.deb .
+RUN apt-get update \
+      && apt-get install -y ./mongodb-database-tools-debian10-x86_64-100.5.2.deb \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/*
+
+FROM tool-common AS postgresql
+
+RUN apt-get update \
+      && apt-get postgresql-common --no-install-recommends \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/*
+
+
+##
+## release
+## dbType is "mongodb" or "postgresql"
+##
+FROM ${dbType} AS release
+
+ARG distDir="dist"
 ARG packageScope
+ARG packagePath
 ENV NODE_ENV production
 ENV optDir /opt
 ENV appDir /app
-WORKDIR ${appDir}
+WORKDIR ${appDir}/${packagePath}
 
 COPY --from=builder --chown=node:node \
   ${optDir}/ ${appDir}/
+
+RUN for F in ls ${distDir}/${packagePath}/src/bin/*.js; do \
+      chmod +x $F; \
+      mv $F $(dirname $F)/$(basename -s .js $F); \
+    done
+ENV PATH $PATH:${appDir}/${packagePath}/${distDir}/${packagePath}/src/bin

--- a/docker/test/mongodb/structure-tests.yml
+++ b/docker/test/mongodb/structure-tests.yml
@@ -41,37 +41,37 @@ commandTests:
 # Execution
 # ================================================================================
 - name: when --help is specified, expect "backup" success
-  command: node
-  args: ["backup", "--help"]
+  command: backup
+  args: ["--help"]
 - name: when no argument is specified, expect "backup" fail with error message
-  command: node
-  args: ["backup"]
+  command: backup
+  args: []
   expectedError: [".*missing required argument 'TARGET_BUCKET_URL'.*"]
   exitCode: 1
 
 - name: when --help is specified, expect "list" success
-  command: node
-  args: ["list", "--help"]
+  command: list
+  args: ["--help"]
 - name: when no argument is specified, expect "list" fail with error message
-  command: node
-  args: ["list"]
+  command: list
+  args: []
   expectedError: [".*missing required argument 'TARGET_BUCKET_URL'.*"]
   exitCode: 1
 
 - name: when --help is specified, expect "prune" success
-  command: node
-  args: ["prune", "--help"]
+  command: prune
+  args: ["--help"]
 - name: when no argument is specified, expect "prune" fail with error message
-  command: node
-  args: ["prune"]
+  command: prune
+  args: []
   expectedError: [".*missing required argument 'TARGET_BUCKET_URL'.*"]
   exitCode: 1
 
 - name: when --help is specified, expect "restore" success
-  command: node
-  args: ["restore", "--help"]
+  command: restore
+  args: ["--help"]
 - name: when no argument is specified, expect "restore" fail with error message
-  command: node
-  args: ["restore"]
+  command: restore
+  args: []
   expectedError: [".*missing required argument 'TARGET_BUCKET_URL'.*"]
   exitCode: 1

--- a/docker/test/mongodb/structure-tests.yml
+++ b/docker/test/mongodb/structure-tests.yml
@@ -1,37 +1,77 @@
 schemaVersion: 2.0.0
 commandTests:
-- name: when --help is specified, "bin/backup" expect success
+# ================================================================================
+# Path
+# ================================================================================
+# ----------
+# scripts
+# ----------
+- name: expect "which backup" return valid path
+  command: which
+  args: ["backup"]
+
+- name: expect "which list" return valid path
+  command: which
+  args: ["list"]
+
+- name: expect "which prune" return valid path
+  command: which
+  args: ["prune"]
+
+- name: expect "which restore" return valid path
+  command: which
+  args: ["restore"]
+
+# ----------
+# backup tools
+# ----------
+- name: expect "which tar" return valid path
+  command: which
+  args: ["tar"]
+
+- name: expect "which bzip2" return valid path
+  command: which
+  args: ["bzip2"]
+
+- name: expect "which mongodump" return valid path
+  command: which
+  args: ["mongodump"]
+
+# ================================================================================
+# Execution
+# ================================================================================
+- name: when --help is specified, expect "backup" success
   command: node
-  args: ["apps/mongodb/dist/apps/mongodb/src/bin/backup.js", "--help"]
-- name: when no argument is specified, "bin/backup" expect fail with error message
+  args: ["backup", "--help"]
+- name: when no argument is specified, expect "backup" fail with error message
   command: node
-  args: ["apps/mongodb/dist/apps/mongodb/src/bin/backup.js"]
+  args: ["backup"]
   expectedError: [".*missing required argument 'TARGET_BUCKET_URL'.*"]
   exitCode: 1
 
-- name: when --help is specified, "bin/list" expect success
+- name: when --help is specified, expect "list" success
   command: node
-  args: ["apps/mongodb/dist/apps/mongodb/src/bin/list.js", "--help"]
-- name: when no argument is specified, "bin/list" expect fail with error message
+  args: ["list", "--help"]
+- name: when no argument is specified, expect "list" fail with error message
   command: node
-  args: ["apps/mongodb/dist/apps/mongodb/src/bin/list.js"]
+  args: ["list"]
   expectedError: [".*missing required argument 'TARGET_BUCKET_URL'.*"]
   exitCode: 1
 
-- name: when --help is specified, "bin/prune" expect success
+- name: when --help is specified, expect "prune" success
   command: node
-  args: ["apps/mongodb/dist/apps/mongodb/src/bin/prune.js", "--help"]
-- name: when no argument is specified, "bin/prune" expect fail with error message
+  args: ["prune", "--help"]
+- name: when no argument is specified, expect "prune" fail with error message
   command: node
-  args: ["apps/mongodb/dist/apps/mongodb/src/bin/prune.js"]
+  args: ["prune"]
   expectedError: [".*missing required argument 'TARGET_BUCKET_URL'.*"]
   exitCode: 1
 
-- name: when --help is specified, "bin/restore" expect success
+- name: when --help is specified, expect "restore" success
   command: node
-  args: ["apps/mongodb/dist/apps/mongodb/src/bin/restore.js", "--help"]
-- name: when no argument is specified, "bin/restore" expect fail with error message
+  args: ["restore", "--help"]
+- name: when no argument is specified, expect "restore" fail with error message
   command: node
-  args: ["apps/mongodb/dist/apps/mongodb/src/bin/restore.js"]
+  args: ["restore"]
   expectedError: [".*missing required argument 'TARGET_BUCKET_URL'.*"]
   exitCode: 1

--- a/docker/test/postgresql/structure-tests.yml
+++ b/docker/test/postgresql/structure-tests.yml
@@ -1,37 +1,77 @@
 schemaVersion: 2.0.0
 commandTests:
-- name: when --help is specified, "bin/backup" expect success
+# ================================================================================
+# Path
+# ================================================================================
+# ----------
+# scripts
+# ----------
+- name: expect "which backup" success
+  command: which
+  args: ["backup"]
+
+- name: expect "which list" success
+  command: which
+  args: ["list"]
+
+- name: expect "which prune" success
+  command: which
+  args: ["prune"]
+
+- name: expect "which restore" success
+  command: which
+  args: ["restore"]
+
+# ----------
+# backup tools
+# ----------
+- name: expect "which tar" success
+  command: which
+  args: ["tar"]
+
+- name: expect "which bzip2" success
+  command: which
+  args: ["bzip2"]
+
+- name: expect "which psql" success
+  command: which
+  args: ["psql"]
+
+# ================================================================================
+# Execution
+# ================================================================================
+- name: when --help is specified, expect "backup" success
   command: node
-  args: ["apps/postgresql/dist/apps/postgresql/src/bin/backup.js", "--help"]
-- name: when no argument is specified, "bin/backup" expect fail with error message
+  args: ["backup", "--help"]
+- name: when no argument is specified, expect "backup" fail with error message
   command: node
-  args: ["apps/postgresql/dist/apps/postgresql/src/bin/backup.js"]
+  args: ["backup"]
   expectedError: [".*missing required argument 'TARGET_BUCKET_URL'.*"]
   exitCode: 1
 
-- name: when --help is specified, "bin/list" expect success
+- name: when --help is specified, expect "list" success
   command: node
-  args: ["apps/postgresql/dist/apps/postgresql/src/bin/list.js", "--help"]
-- name: when no argument is specified, "bin/list" expect fail with error message
+  args: ["list", "--help"]
+- name: when no argument is specified, expect "list" fail with error message
   command: node
-  args: ["apps/postgresql/dist/apps/postgresql/src/bin/list.js"]
+  args: ["list"]
   expectedError: [".*missing required argument 'TARGET_BUCKET_URL'.*"]
   exitCode: 1
 
-- name: when --help is specified, "bin/prune" expect success
+- name: when --help is specified, expect "prune" success
   command: node
-  args: ["apps/postgresql/dist/apps/postgresql/src/bin/prune.js", "--help"]
-- name: when no argument is specified, "bin/prune" expect fail with error message
+  args: ["prune", "--help"]
+- name: when no argument is specified, expect "prune" fail with error message
   command: node
-  args: ["apps/postgresql/dist/apps/postgresql/src/bin/prune.js"]
+  args: ["prune"]
   expectedError: [".*missing required argument 'TARGET_BUCKET_URL'.*"]
   exitCode: 1
 
-- name: when --help is specified, "bin/restore" expect success
+- name: when --help is specified, expect "restore" success
   command: node
-  args: ["apps/postgresql/dist/apps/postgresql/src/bin/restore.js", "--help"]
-- name: when no argument is specified, "bin/restore" expect fail with error message
+  args: ["restore", "--help"]
+- name: when no argument is specified, expect "restore" fail with error message
   command: node
-  args: ["apps/postgresql/dist/apps/postgresql/src/bin/restore.js"]
+  args: ["restore"]
   expectedError: [".*missing required argument 'TARGET_BUCKET_URL'.*"]
   exitCode: 1

--- a/docker/test/postgresql/structure-tests.yml
+++ b/docker/test/postgresql/structure-tests.yml
@@ -41,37 +41,37 @@ commandTests:
 # Execution
 # ================================================================================
 - name: when --help is specified, expect "backup" success
-  command: node
-  args: ["backup", "--help"]
+  command: backup
+  args: ["--help"]
 - name: when no argument is specified, expect "backup" fail with error message
-  command: node
-  args: ["backup"]
+  command: backup
+  args: []
   expectedError: [".*missing required argument 'TARGET_BUCKET_URL'.*"]
   exitCode: 1
 
 - name: when --help is specified, expect "list" success
-  command: node
-  args: ["list", "--help"]
+  command: list
+  args: ["--help"]
 - name: when no argument is specified, expect "list" fail with error message
-  command: node
-  args: ["list"]
+  command: list
+  args: []
   expectedError: [".*missing required argument 'TARGET_BUCKET_URL'.*"]
   exitCode: 1
 
 - name: when --help is specified, expect "prune" success
-  command: node
-  args: ["prune", "--help"]
+  command: prune
+  args: ["--help"]
 - name: when no argument is specified, expect "prune" fail with error message
-  command: node
-  args: ["prune"]
+  command: prune
+  args: []
   expectedError: [".*missing required argument 'TARGET_BUCKET_URL'.*"]
   exitCode: 1
 
 - name: when --help is specified, expect "restore" success
-  command: node
-  args: ["restore", "--help"]
+  command: restore
+  args: ["--help"]
 - name: when no argument is specified, expect "restore" fail with error message
-  command: node
-  args: ["restore"]
+  command: restore
+  args: []
   expectedError: [".*missing required argument 'TARGET_BUCKET_URL'.*"]
   exitCode: 1

--- a/packages/core/src/commands/backup.ts
+++ b/packages/core/src/commands/backup.ts
@@ -121,7 +121,7 @@ export class BackupCommand extends Command {
 
         const targetBucketUrl = new URL(targetBucketUrlString);
         const actionImpl = (options.cronmode ? this.backupCronMode : this.backupOnce);
-        await actionImpl(
+        await actionImpl.bind(this)(
           storageServiceClientHolder.storageServiceClient,
           dumpDatabaseFunc,
           targetBucketUrl,

--- a/packages/core/src/commands/common.ts
+++ b/packages/core/src/commands/common.ts
@@ -2,7 +2,7 @@
  * Define common processing for "backup", "restore", "list", and "prune" commands.
  */
 
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import { IStorageServiceClient } from '../interfaces/storage-service-client';
 import { storageProviderType, generateStorageServiceClient } from '../factories/provider-factory';
 
@@ -21,14 +21,14 @@ export function addStorageServiceClientOptions(command: Command): void {
   command
     /* AWS options */
     .option('--aws-region <AWS_REGION>', 'AWS Region')
-    .option('--aws-access-key-id <AWS_ACCESS_KEY_ID>', 'Your IAM Access Key ID', process.env.AWS_ACCESS_KEY_ID)
-    .option('--aws-secret-access-key <AWS_SECRET_ACCESS_KEY>', 'Your IAM Secret Access Key', process.env.AWS_SECRET_ACCESS_KEY)
+    .addOption(new Option('--aws-access-key-id <AWS_ACCESS_KEY_ID>', 'Your IAM Access Key ID').env('AWS_ACCESS_KEY_ID'))
+    .addOption(new Option('--aws-secret-access-key <AWS_SECRET_ACCESS_KEY>', 'Your IAM Secret Access Key').env('AWS_SECRET_ACCESS_KEY'))
     /* GCS options */
-    .option('--gcp-project-id <GCP_PROJECT_ID>', 'GCP Project ID', process.env.GCLOUD_PROJECT)
+    .addOption(new Option('--gcp-project-id <GCP_PROJECT_ID>', 'GCP Project ID').env('GCLOUD_PROJECT'))
     .option('--gcp-private-key <GCP_PRIVATE_KEY>', 'GCP Private Key')
-    .option('--gcp-client-email, <GCP_CLIENT_EMAIL>', 'GCP Client Email')
-    .option('--gcp-service-account-key-json-path <GCP_SERVICE_ACCOUNT_KEY_JSON_PATH>',
-      'JSON file path to your GCP Service Account Key', process.env.GOOGLE_APPLICATION_CREDENTIALS);
+    .option('--gcp-client-email <GCP_CLIENT_EMAIL>', 'GCP Client Email')
+    .addOption(new Option('--gcp-service-account-key-json-path <GCP_SERVICE_ACCOUNT_KEY_JSON_PATH>',
+      'JSON file path to your GCP Service Account Key').env('GOOGLE_APPLICATION_CREDENTIALS'));
 }
 
 export function addStorageServiceClientGenerateHook(command: Command, storageServiceClientHolder: { storageServiceClient: IStorageServiceClient|null }): void {

--- a/packages/core/src/factories/provider-factory.ts
+++ b/packages/core/src/factories/provider-factory.ts
@@ -56,7 +56,7 @@ export function generateGCSServiceClient({
     and it will be deleted when process exit. */
   if (![gcpProjectId, gcpClientEmail, gcpPrivateKey].every(it => it != null)) {
     throw new Error('If you does not set "--gcp-service-account-key-json-path", '
-                      + 'you will need to set all of "--gcp-project-id", "--gcp-access-key-id" and "--gcp-secret-access-key".');
+                      + 'you will need to set all of "--gcp-project-id", "--gcp-client-email" and "--gcp-private-key".');
   }
 
   // [MEMO] Converting escaped characters because newline codes cannot be entered in the commander argument.


### PR DESCRIPTION
- install backup tools to docker container
- set path to scripts (`backup`, `list`, `prune`, `restore`) in docker container
- use env method instead of setting env as default value
- fix option names in an error message
