### PR TITLE
logging multi line

### DIFF
--- a/packages/core/src/commands/backup.ts
+++ b/packages/core/src/commands/backup.ts
@@ -3,6 +3,7 @@ import { basename, join } from 'path';
 import { Command, Option } from 'commander';
 import axios from 'axios';
 import axiosRetry from 'axios-retry';
+import { EOL } from 'os';
 import { compressBZIP2 } from '../utils/tar';
 import { IStorageServiceClient } from '../storage-service-clients/interfaces';
 import { IBackupCommandOption } from './interfaces';
@@ -41,8 +42,8 @@ export class BackupCommand extends Command {
 
     logger.info(`backup ${backupFilePath}...`);
     const { stdout, stderr } = await dumpDatabaseFunc(backupFilePath, options.backupToolOptions);
-    if (stdout) logger.info(stdout);
-    if (stderr) logger.warn(stderr);
+    if (stdout) stdout.split(EOL).forEach(line => logger.info(line));
+    if (stderr) stderr.split(EOL).forEach(line => logger.warn(line));
 
     const { compressedFilePath } = await compressBZIP2(backupFilePath);
     await storageServiceClient.copyFile(compressedFilePath, targetBucketUrl.toString());

--- a/packages/core/src/commands/list.ts
+++ b/packages/core/src/commands/list.ts
@@ -23,9 +23,11 @@ export class ListCommand extends Command {
       storageServiceClient: IStorageServiceClient,
       targetBucketUrl: URL,
   ): Promise<void> {
-    logger.info('There are files below in bucket:');
     const files = await storageServiceClient.listFiles(targetBucketUrl.toString());
-    logger.info(files.join(EOL));
+    if (files.length > 0) {
+      logger.info('There are files below in bucket:');
+      logger.info(files.join(EOL));
+    }
   }
 
   addListOptions(): ListCommand {

--- a/packages/core/src/commands/restore.ts
+++ b/packages/core/src/commands/restore.ts
@@ -1,7 +1,7 @@
 import { format } from 'date-fns';
 import { basename, join } from 'path';
 import { Command, Option } from 'commander';
-
+import { EOL } from 'os';
 import { expandBZIP2 } from '../utils/tar';
 import { IStorageServiceClient } from '../storage-service-clients/interfaces';
 import { IRestoreCommandOption } from './interfaces';
@@ -40,8 +40,8 @@ export class RestoreCommand extends Command {
     logger.info(`expands ${backupFilePath}...`);
     const { expandedPath } = await expandBZIP2(backupFilePath);
     const { stdout, stderr } = await restoreDatabaseFunc(expandedPath, options.restoreToolOptions);
-    if (stdout) logger.info(stdout);
-    if (stderr) logger.warn(stderr);
+    if (stdout) stdout.split(EOL).forEach(line => logger.info(line));
+    if (stderr) stderr.split(EOL).forEach(line => logger.warn(line));
   }
 
   addRestoreOptions(): RestoreCommand {


### PR DESCRIPTION
fix logging multi line

before: 

```
[2022-04-17T15:58:51.081Z]  WARN: mongodb-awesome-backup/8 on colllet-back-backup-daily-test-k58ng:
  2022-04-17T15:58:51.077+0000      writing colllet.users to /tmp/tmp-8-CEDgUstSFrAh/backup-20220417155851/colllet/users.bson
  2022-04-17T15:58:51.078+0000      done dumping colllet.users (54 documents)
```

after:

```
[2022-04-17T15:58:51.081Z]  WARN: mongodb-awesome-backup/8 on colllet-back-backup-daily-test-k58ng:
[2022-04-17T15:58:51.081Z]  WARN:   2022-04-17T15:58:51.077+0000      writing colllet.users to /tmp/tmp-8-CEDgUstSFrAh/backup-20220417155851/colllet/users.bson
[2022-04-17T15:58:51.081Z]  WARN:   2022-04-17T15:58:51.078+0000      done dumping colllet.users (54 documents)
```